### PR TITLE
feat(run-app): implement state-based app icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
         "@elgato/streamdeck": "^1.0.0",
         "@node-steam/vdf": "^2.2.0",
         "decode-ico": "^0.4.1",
-        "open": "^10.2.0"
+        "open": "^10.2.0",
+        "upng-js": "^2.1.0"
       },
       "devDependencies": {
         "@elgato/cli": "^1.5.0",
@@ -1729,6 +1730,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -2116,6 +2123,15 @@
       "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/upng-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/upng-js/-/upng-js-2.1.0.tgz",
+      "integrity": "sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.5"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@elgato/streamdeck": "^1.0.0",
         "@node-steam/vdf": "^2.2.0",
+        "decode-ico": "^0.4.1",
         "open": "^10.2.0"
       },
       "devDependencies": {
@@ -21,6 +22,12 @@
         "tslib": "^2.6.2",
         "typescript": "^5.2.2"
       }
+    },
+    "node_modules/@canvas/image-data": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@canvas/image-data/-/image-data-1.1.0.tgz",
+      "integrity": "sha512-QdObRRjRbcXGmM1tmJ+MrHcaz1MftF2+W7YI+MsphnsCrmtyfS0d5qJbk0MeSbUeyM/jCb0hmnkXPsy026L7dA==",
+      "license": "MIT"
     },
     "node_modules/@elgato/cli": {
       "version": "1.5.0",
@@ -1153,6 +1160,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-bmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/decode-bmp/-/decode-bmp-0.2.1.tgz",
+      "integrity": "sha512-NiOaGe+GN0KJqi2STf24hfMkFitDUaIoUU3eKvP/wAbLe8o6FuW5n/x7MHPR0HKvBokp6MQY/j7w8lewEeVCIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@canvas/image-data": "^1.0.0",
+        "to-data-view": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/decode-ico": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-ico/-/decode-ico-0.4.1.tgz",
+      "integrity": "sha512-69NZfbKIzux1vBOd31al3XnMnH+2mqDhEgLdpygErm4d60N+UwA5Sq5WFjmEDQzumgB9fElojGwWG0vybVfFmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@canvas/image-data": "^1.0.0",
+        "decode-bmp": "^0.2.0",
+        "to-data-view": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2033,6 +2067,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-data-view": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+      "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
       "license": "MIT"
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@elgato/streamdeck": "^1.0.0",
     "@node-steam/vdf": "^2.2.0",
+    "decode-ico": "^0.4.1",
     "open": "^10.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@elgato/streamdeck": "^1.0.0",
     "@node-steam/vdf": "^2.2.0",
     "decode-ico": "^0.4.1",
-    "open": "^10.2.0"
+    "open": "^10.2.0",
+    "upng-js": "^2.1.0"
   }
 }

--- a/src/services/image-compositor.ts
+++ b/src/services/image-compositor.ts
@@ -1,0 +1,130 @@
+export type BadgeType = "update" | "running" | "downloading";
+
+export type BadgePosition =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
+
+export interface CompositeOptions {
+  grayscale?: boolean;
+  badge?: BadgeType;
+  badgePosition?: BadgePosition;
+}
+
+// Stream Deck key icon size
+const ICON_SIZE = 144;
+const BADGE_SIZE = 48;
+const BADGE_PADDING = 4;
+
+// Badge SVG content (viewBox 0 0 24 24)
+const BADGE_SVG_CONTENT: Record<BadgeType, string> = {
+  update: `<path d="M5.07,8A8,8,0,0,1,20,12" style="fill: none; stroke: rgb(0, 0, 0); stroke-linecap: round; stroke-linejoin: round; stroke-width: 2;"></path><path d="M18.93,16A8,8,0,0,1,4,12" style="fill: none; stroke: rgb(0, 0, 0); stroke-linecap: round; stroke-linejoin: round; stroke-width: 2;"></path><polyline points="5 3 5 8 10 8" style="fill: none; stroke: rgb(0, 0, 0); stroke-linecap: round; stroke-linejoin: round; stroke-width: 2;"></polyline><polyline points="19 21 19 16 14 16" style="fill: none; stroke: rgb(0, 0, 0); stroke-linecap: round; stroke-linejoin: round; stroke-width: 2;"></polyline>`,
+  running: `<polygon points="5,3 19,12 5,21" style="fill: none; stroke: rgb(0, 0, 0); stroke-linecap: round; stroke-linejoin: round; stroke-width: 2;"/>`,
+  downloading: `<path d="M12,3 L12,15 M12,15 L7,10 M12,15 L17,10" style="fill: none; stroke: rgb(0, 0, 0); stroke-linecap: round; stroke-linejoin: round; stroke-width: 2;"/><path d="M5,21 L19,21" style="fill: none; stroke: rgb(0, 0, 0); stroke-linecap: round; stroke-linejoin: round; stroke-width: 2;"/>`,
+};
+
+/**
+ * Computes badge position coordinates
+ */
+function getBadgeCoordinates(position: BadgePosition): {
+  x: number;
+  y: number;
+} {
+  switch (position) {
+    case "top-left":
+      return { x: BADGE_PADDING, y: BADGE_PADDING };
+    case "top-right":
+      return { x: ICON_SIZE - BADGE_SIZE - BADGE_PADDING, y: BADGE_PADDING };
+    case "bottom-left":
+      return { x: BADGE_PADDING, y: ICON_SIZE - BADGE_SIZE - BADGE_PADDING };
+    case "bottom-right":
+    default:
+      return {
+        x: ICON_SIZE - BADGE_SIZE - BADGE_PADDING,
+        y: ICON_SIZE - BADGE_SIZE - BADGE_PADDING,
+      };
+  }
+}
+
+/**
+ * Composites an app icon with optional grayscale filter and badge overlay.
+ * Returns a base64 data URI of the final SVG.
+ */
+export function compositeAppIcon(
+  iconBase64: string,
+  options: CompositeOptions = {},
+): string {
+  const { grayscale = false, badge, badgePosition = "bottom-right" } = options;
+
+  // Build filter definitions
+  let filterDefs = "";
+  let imageFilter = "";
+
+  if (grayscale) {
+    filterDefs = `
+    <filter id="grayscale">
+      <feColorMatrix type="saturate" values="0"/>
+    </filter>`;
+    imageFilter = 'filter="url(#grayscale)"';
+  }
+
+  // Build badge element
+  let badgeElement = "";
+
+  if (badge) {
+    const badgeContent = BADGE_SVG_CONTENT[badge];
+    const { x, y } = getBadgeCoordinates(badgePosition);
+
+    // Scale the badge from its viewBox (24x24) to BADGE_SIZE
+    const scale = BADGE_SIZE / 24;
+
+    badgeElement = `
+    <g transform="translate(${x}, ${y}) scale(${scale})">
+      ${badgeContent}
+    </g>`;
+  }
+
+  // Compose final SVG
+  const compositeSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="${ICON_SIZE}" height="${ICON_SIZE}">
+  <defs>${filterDefs}
+  </defs>
+  <image href="${iconBase64}" width="${ICON_SIZE}" height="${ICON_SIZE}" ${imageFilter}/>
+  ${badgeElement}
+</svg>`;
+
+  // Convert to base64 data URI
+  const base64 = Buffer.from(compositeSvg).toString("base64");
+  return `data:image/svg+xml;base64,${base64}`;
+}
+
+/**
+ * Determines composite options based on Steam app state flags
+ */
+export function getCompositeOptionsFromStateFlags(
+  stateFlags: number,
+): CompositeOptions | null {
+  // Check states in priority order
+
+  if (stateFlags & SteamStateFlags.AppRunning) {
+    return { badge: "running" };
+  }
+
+  const updateInProgressFlags =
+    SteamStateFlags.UpdateRunning |
+    SteamStateFlags.UpdateStarted |
+    SteamStateFlags.Downloading |
+    SteamStateFlags.Staging |
+    SteamStateFlags.Committing;
+
+  if (stateFlags & updateInProgressFlags) {
+    return { badge: "downloading" };
+  }
+
+  if (stateFlags & SteamStateFlags.UpdateRequired) {
+    return { grayscale: true, badge: "update" };
+  }
+
+  // Fully installed, no special treatment
+  return null;
+}

--- a/src/services/steam.ts
+++ b/src/services/steam.ts
@@ -243,7 +243,7 @@ class SteamLibrary {
           id: Number(gameData.appid) || 0,
           name: gameData.name || "",
           installDir: gameData.installdir || "",
-          stateFlags: gameData.StateFlags || "",
+          stateFlags: Number(gameData.StateFlags) || 0,
         };
 
         return game;
@@ -614,5 +614,10 @@ export class Steam {
   // Library - Icons
   async getAppIconBase64(appId: string): Promise<string | null> {
     return this.library.getAppIconBase64(appId);
+  }
+
+  // Library - App lookup
+  getAppById(appId: string): SteamApp | undefined {
+    return this.library.installedApps.find((a) => a.id.toString() === appId);
   }
 }

--- a/src/services/steam.ts
+++ b/src/services/steam.ts
@@ -57,6 +57,11 @@ class SteamUserRegistry {
 class SteamLibrary {
   private static readonly debugPrefix = "[SteamLibrary]";
 
+  // Apps to exclude from installed apps list
+  private static readonly appExceptions = new Set<number>([
+    228980, // Steamworks Common Redistributables
+  ]);
+
   // Icons to skip (no proper icon available)
   private static readonly iconExceptions = new Set([
     "SteamMovie", // Not a game icon
@@ -93,7 +98,9 @@ class SteamLibrary {
   }
 
   get installedApps(): SteamApp[] {
-    return this._installedApps;
+    return this._installedApps.filter(
+      (app) => !SteamLibrary.appExceptions.has(app.id),
+    );
   }
 
   async getAppIconBase64(appId: string): Promise<string | null> {
@@ -233,7 +240,7 @@ class SteamLibrary {
         const gameData = (parsedContent as any).AppState || parsedContent;
 
         const game: SteamApp = {
-          id: gameData.appid || "",
+          id: Number(gameData.appid) || 0,
           name: gameData.name || "",
           installDir: gameData.installdir || "",
           stateFlags: gameData.StateFlags || "",

--- a/src/types/steam.d.ts
+++ b/src/types/steam.d.ts
@@ -13,11 +13,40 @@ type SteamLibraryFolders = {
   apps: string[];
 };
 
+/**
+ * Steam app state flags (bitmask values from .acf manifests)
+ * @see https://github.com/lutris/lutris/blob/master/docs/steam.rst
+ */
+declare const enum SteamStateFlags {
+  Invalid = 0,
+  Uninstalled = 1,
+  UpdateRequired = 2,
+  FullyInstalled = 4,
+  Encrypted = 8,
+  Locked = 16,
+  FilesMissing = 32,
+  AppRunning = 64,
+  FilesCorrupt = 128,
+  UpdateRunning = 256,
+  UpdatePaused = 512,
+  UpdateStarted = 1024,
+  Uninstalling = 2048,
+  BackupRunning = 4096,
+  Reconfiguring = 65536,
+  Validating = 131072,
+  AddingFiles = 262144,
+  Preallocating = 524288,
+  Downloading = 1048576,
+  Staging = 2097152,
+  Committing = 4194304,
+  UpdateStopping = 8388608,
+}
+
 type SteamApp = {
   id: number;
   name: string;
   installDir: string;
-  stateFlags: string;
+  stateFlags: number;
 };
 
 type PluginGlobalSettings = {

--- a/src/types/steam.d.ts
+++ b/src/types/steam.d.ts
@@ -11,23 +11,23 @@ type SteamLibraryFolders = {
   contentid: string;
   totalsize: string;
   apps: string[];
-}
+};
 
 type SteamApp = {
-  id: string;
+  id: number;
   name: string;
   installDir: string;
   stateFlags: string;
-}
+};
 
 type PluginGlobalSettings = {
   installedGames?: SteamGame[];
   lastLibraryUpdate?: string;
-}
+};
 
 type SteamUser = {
   steamId64: string;
   accountName: string;
   personaName: string;
   avatarBase64: string;
-}
+};

--- a/src/types/upng-js.d.ts
+++ b/src/types/upng-js.d.ts
@@ -1,0 +1,48 @@
+declare module "upng-js" {
+  /**
+   * Encode RGBA image data to PNG
+   * @param imgs Array of ArrayBuffer containing RGBA pixel data
+   * @param w Width of the image
+   * @param h Height of the image
+   * @param cnum Number of colors in the palette (0 for truecolor PNG)
+   * @param dels Optional array of delays for animated PNGs
+   * @returns ArrayBuffer containing the encoded PNG data
+   */
+  function encode(
+    imgs: ArrayBuffer[],
+    w: number,
+    h: number,
+    cnum: number,
+    dels?: number[],
+  ): ArrayBuffer;
+
+  /**
+   * Decode PNG data
+   * @param buffer ArrayBuffer containing PNG data
+   * @returns Decoded PNG object
+   */
+  function decode(buffer: ArrayBuffer): {
+    width: number;
+    height: number;
+    depth: number;
+    ctype: number;
+    frames: Array<{
+      rect: { x: number; y: number; width: number; height: number };
+      blend: number;
+      dispose: number;
+      delay: number;
+    }>;
+    tabs: Record<string, unknown>;
+    data: Uint8Array;
+  };
+
+  /**
+   * Convert decoded PNG frames to RGBA
+   * @param png Decoded PNG object from decode()
+   * @returns Array of Uint8Array containing RGBA pixel data for each frame
+   */
+  function toRGBA8(png: ReturnType<typeof decode>): Uint8Array[];
+
+  export { encode, decode, toRGBA8 };
+  export default { encode, decode, toRGBA8 };
+}


### PR DESCRIPTION
## Description
Introduces a system for fetching, displaying, and updating Steam app icons, providing visual feedback based on the application's state.

## Added dependencies
- [`upng-js`](https://www.npmjs.com/package/@nbfe/upng-js)
- [`decode-ico`](https://www.npmjs.com/package/decode-ico?activeTab=readme)

## Classes
### `SteamCMD`  (Updated)
New class with (currently) single method was added to query the `steamcmd.net` API, retrieving the `clienticon` hash for a given application ID. This hash is the key to locating the correct icon file within the local Steam directory.

### `SteamLibrary` (Updated)
- **Icon extraction**: This class now contains the primary logic for icon retrieval. It reads `.ico` files from the local `Steam/steam/games/` directory. Then it parses them to find the largest available image, and prepares it for display on the Stream Deck.
-  **`BMP` to `PNG` conversion**: To handle older or non-standard `.ico` files, the `upng-js` library has been added. This allows the plugin to convert raw `BMP` image data into the `PNG` format.

### `ImageCompositor` (New)
- **SVG composition**: The service is responsible for creating the final icon. It takes the base `PNG` and composites it into an `SVG`, allowing for filters and/or overlay badges.
- **State-based effects**: The compositor applies visual effects based on the application's status. For example, it can apply a grayscale filter for an app that needs an update.